### PR TITLE
feat(dependabot): execute monthly (instead of weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,6 @@ updates:
     allow:
       - dependency-type: "all"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+    reviewers:
+      - "johnsudaar"


### PR DESCRIPTION
Following a discussion on Slack, we want to execute Dependabot monthly instead of weekly to lighten the work.