### PR TITLE
chore(github): workflow Go version update from 1.14 to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Import GPG key
         id: import_gpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be released
 
+* chore(github): workflow Go version update from 1.14 to 1.17
+
 ## v1.3.2
 
 * chore(go): use go 1.17


### PR DESCRIPTION
Because currently the GitHub Action workflow fails: https://github.com/Scalingo/terraform-provider-encrypted/runs/6809050270?check_suite_focus=true